### PR TITLE
Optimize advanced glow visibility

### DIFF
--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -87,6 +87,7 @@ public class AdvancedGlowVisibilityAddon {
 
                         double angle = nearbyDir.angle(playerDir);
                         if (angle > FRUSTUM_SIZE) {
+                            toggle(ePlayer, nearby, false);
                             continue;
                         } else {
                             Raytrace trace = new Raytrace(playerLoc, nearbyLoc);

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -29,7 +29,7 @@ public class AdvancedGlowVisibilityAddon {
 
     private boolean FORCE_STOP = false;
     private static final List<Material> ignoredBlocks = new ArrayList<>();
-    private final Map<UUID, Location> cache = new HashMap<>(); //todo: fix memory leak when players disconnect
+    private final Map<UUID, Location> cache = new HashMap<>();
     /**
      * Whether a glow check is currently being run.
      */
@@ -136,6 +136,12 @@ public class AdvancedGlowVisibilityAddon {
         } else {
             p1.removeGlowTarget(p2.getPlayer());
             p2.removeGlowTarget(p1.getPlayer());
+        }
+    }
+
+    public void uncachePlayer(IEGlowPlayer ePlayer) {
+        synchronized (cache) {
+            cache.remove(ePlayer.getUUID());
         }
     }
 

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 public class AdvancedGlowVisibilityAddon {
 
     private static final double FRUSTUM_SIZE = Math.toRadians(120); // How large the frustum volume is, in radians.
+    private static final int MAX_DISTANCE = 50;
 
     private boolean FORCE_STOP = false;
     private static final List<Material> ignoredBlocks = new ArrayList<>();
@@ -68,7 +69,7 @@ public class AdvancedGlowVisibilityAddon {
 
                     List<IEGlowPlayer> nearbyEPlayers = new ArrayList<>();
                     for (Player p : playerLoc.getWorld().getPlayers()) {
-                        if (p != player && distance(p.getEyeLocation(), playerLoc) < 50) {
+                        if (p != player && distance(p.getEyeLocation(), playerLoc) < MAX_DISTANCE) {
                             nearbyEPlayers.add(DataManager.getEGlowPlayer(p));
                         }
                     }

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -113,7 +113,7 @@ public class AdvancedGlowVisibilityAddon {
         if (cached == null) {
             cache.put(ePlayer.getUUID(), playerLoc);
         } else {
-            if (xyzEquals(cached, playerLoc)) {
+            if (cached.equals(playerLoc)) {
                 return true;
             } else {
                 cache.replace(ePlayer.getUUID(), playerLoc);
@@ -340,17 +340,6 @@ public class AdvancedGlowVisibilityAddon {
 
     private boolean getForceStop() {
         return this.FORCE_STOP;
-    }
-
-    /**
-     * Checks if the X, Y, and Z values of two Location are equal.
-     *
-     * @param loc1 The first Location.
-     * @param loc2 The second Location.
-     * @return True if the X, Y, and Z values are equal, false otherwise.
-     */
-    private static boolean xyzEquals(Location loc1, Location loc2) {
-        return loc1.getX() == loc2.getX() && loc1.getY() == loc2.getY() && loc1.getZ() == loc2.getZ();
     }
 
     public static class Raytrace {

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -16,13 +16,11 @@ import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 public class AdvancedGlowVisibilityAddon {
 

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -266,15 +266,13 @@ public class AdvancedGlowVisibilityAddon {
             ignoredBlocks.add(Material.valueOf("SEA_PICKLE"));
             ignoredBlocks.add(Material.valueOf("TURTLE_EGG"));
 
-            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 14) {
+            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 14)
                 ignoredBlocks.add(Material.valueOf("SCAFFOLDING"));
-            }
 
-            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 15) {
+            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 15)
                 ignoredBlocks.add(Material.valueOf("HONEY_BLOCK"));
-            }
 
-            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 16) {
+            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 16)
                 ignoredBlocks.add(Material.valueOf("CHAIN"));
                 ignoredBlocks.add(Material.valueOf("CRIMSON_FENCE"));
                 ignoredBlocks.add(Material.valueOf("WARPED_FENCE"));
@@ -288,7 +286,6 @@ public class AdvancedGlowVisibilityAddon {
                 ignoredBlocks.add(Material.valueOf("FLOWERING_AZALEA_LEAVES"));
                 ignoredBlocks.add(Material.valueOf("CRIMSON_FENCE_GATE"));
                 ignoredBlocks.add(Material.valueOf("WARPED_FENCE_GATE"));
-            }
 
             if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 17) {
                 ignoredBlocks.add(Material.valueOf("SMALL_AMETHYST_BUD"));
@@ -318,7 +315,7 @@ public class AdvancedGlowVisibilityAddon {
                 ignoredBlocks.add(Material.valueOf("MOSS_CARPET"));
             }
 
-            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >= 19) {
+            if (ProtocolVersion.SERVER_VERSION.getMinorVersion() >=19)
                 ignoredBlocks.add(Material.valueOf("MANGROVE_FENCE"));
                 ignoredBlocks.add(Material.valueOf("MANGROVE_FENCE_GATE"));
                 ignoredBlocks.add(Material.valueOf("MANGROVE_LEAVES"));
@@ -326,7 +323,6 @@ public class AdvancedGlowVisibilityAddon {
                 ignoredBlocks.add(Material.valueOf("MANGROVE_DOOR"));
                 ignoredBlocks.add(Material.valueOf("MANGROVE_FENCE_GATE"));
                 ignoredBlocks.add(Material.valueOf("MANGROVE_ROOTS"));
-            }
         }
     }
 

--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -62,7 +62,7 @@ public class AdvancedGlowVisibilityAddon {
                     Player player = ePlayer.getPlayer();
                     Location playerLoc = player.getEyeLocation();
 
-                    if (checkCache(ePlayer, playerLoc))
+                    if (checkLocationCache(ePlayer, playerLoc))
                         continue;
 
                     List<IEGlowPlayer> nearbyEPlayers = new ArrayList<>();
@@ -85,12 +85,12 @@ public class AdvancedGlowVisibilityAddon {
 
                         double angle = nearbyDir.angle(playerDir);
                         if (angle > FRUSTUM_SIZE) {
-                            toggle(ePlayer, nearby, false);
+                            toggleGlow(ePlayer, nearby, false);
                             continue;
                         } else {
                             Raytrace trace = new Raytrace(playerLoc, nearbyLoc);
                             boolean hasLineOfSight = trace.hasLineOfSight();
-                            toggle(ePlayer, nearby, hasLineOfSight);
+                            toggleGlow(ePlayer, nearby, hasLineOfSight);
                         }
                         checkedPlayers.add(pair);
                     }
@@ -107,7 +107,7 @@ public class AdvancedGlowVisibilityAddon {
      * @param playerLoc The location to check against.
      * @return True if the players location hasn't changed, false otherwise.
      */
-    private boolean checkCache(IEGlowPlayer ePlayer, Location playerLoc) {
+    private boolean checkLocationCache(IEGlowPlayer ePlayer, Location playerLoc) {
         Location cached = cache.get(ePlayer.getUUID());
 
         if (cached == null) {
@@ -129,7 +129,7 @@ public class AdvancedGlowVisibilityAddon {
      * @param p2     Player 2.
      * @param toggle Whether to enable, or disable glow.
      */
-    private void toggle(IEGlowPlayer p1, IEGlowPlayer p2, boolean toggle) {
+    private void toggleGlow(IEGlowPlayer p1, IEGlowPlayer p2, boolean toggle) {
         if (toggle) {
             p1.addGlowTarget(p2.getPlayer());
             p2.addGlowTarget(p1.getPlayer());

--- a/src/main/java/me/MrGraycat/eGlow/EGlow.java
+++ b/src/main/java/me/MrGraycat/eGlow/EGlow.java
@@ -111,7 +111,7 @@ public class EGlow extends JavaPlugin {
 				getMetricsAddon().addCustomChart(new SimplePie("command_aliases", () -> (MainConfig.COMMAND_ALIAS_ENABLE.getBoolean() && !MainConfig.COMMAND_ALIAS.getString().equalsIgnoreCase("eglow")) ? MainConfig.COMMAND_ALIAS.getString().toLowerCase() : "none"));
 
 				if (MainConfig.ADVANCED_GLOW_VISIBILITY_ENABLE.getBoolean() && getAdvancedGlowVisibility() == null)
-					new AdvancedGlowVisibilityAddon();
+					setAdvancedGlowVisibility(new AdvancedGlowVisibilityAddon());
 				if (DebugUtil.pluginCheck("PlaceholderAPI"))
 					new PlaceholderAPIAddon();
 				if (DebugUtil.pluginCheck("Vault"))

--- a/src/main/java/me/MrGraycat/eGlow/Event/EGlowEventListener.java
+++ b/src/main/java/me/MrGraycat/eGlow/Event/EGlowEventListener.java
@@ -202,6 +202,7 @@ public class EGlowEventListener implements Listener {
 			
 			PipelineInjector.uninject(eglowPlayer);
 			DataManager.removeEGlowPlayer(eglowPlayer.getPlayer());
+			EGlow.getInstance().getAdvancedGlowVisibility().uncachePlayer(eglowPlayer);
 		}
 	}
 }

--- a/src/main/java/me/MrGraycat/eGlow/Util/BiPair.java
+++ b/src/main/java/me/MrGraycat/eGlow/Util/BiPair.java
@@ -1,0 +1,47 @@
+package me.MrGraycat.eGlow.Util;
+
+import java.util.Objects;
+
+/**
+ * A simple utility class to store key-value pairs, ignoring order when comparing equality.
+ */
+public class BiPair<K, V> {
+
+    private final K key;
+    private final V value;
+
+    public BiPair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BiPair<?, ?> biPair = (BiPair<?, ?>) o;
+        return (Objects.equals(key, biPair.key) && Objects.equals(value, biPair.value)) || (Objects.equals(key, biPair.value) && Objects.equals(value, biPair.key));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return "BiPair{" +
+                "key=" + key +
+                ", value=" + value +
+                '}';
+    }
+
+}


### PR DESCRIPTION
Optimizes advanced glow visibility in two main ways:
- Only check visibility between two players once
    - Before, visibility would be checked both ways between two players. The odds of only one player being able to see the other is extremely low, so it's not worth checking the line of sight twice.
- "Frustum culling"
    - Before checking if there is a line of sight, it will check to see if the players are actually looking at one another. This avoids running the BlockIterator when players are looking in separate directions.

It also fixes a minor memory leak where players were not being removed from the location cache when they disconnect.

While all appears to be working fine from my end, there should be some more testing done to ensure that it doesn't break under any edge cases.