### PR TITLE
Add GitHub action to perform builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '18'
+          distribution: 'temurin'
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@master
+
+      - name: Download BuildTools
+        run: wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+
+      - name: Run BuildTools 1.19.1
+        run: java -jar BuildTools.jar --rev 1.19.1
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Compiled JARs
+          path: build/libs


### PR DESCRIPTION
This adds a GitHub action to perform automatic builds.

The primary goal of this would be to ensure all pull requests build correctly before being merged, and ensures they haven't [tampered with the `gradle-wrapper.jar`](https://github.com/gradle/wrapper-validation-action#the-gradle-wrapper-problem-in-open-source).

It also allows people to download the artifacts that were built, which if you don't like, can be disabled by removing the `upload-artifact` action at the end of the file.

The main downside of this action is that since the project depends on the `spigot` artifact, it needs to run BuildTools before building. This means that when that dependency is updated, the `gradle.yml` needs to be updated accordingly. This issue can be avoided entirely by using [paperweight](https://github.com/PaperMC/paperweight).

Before this action will succeed, #13 needs to be merged as it depends on the Gradle wrapper being present.