### PR TITLE
Improve advanced visibility location cache synchronization

### DIFF
--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public class AdvancedGlowVisibilityAddon {
@@ -47,12 +47,7 @@ public class AdvancedGlowVisibilityAddon {
     }
 
     private boolean FORCE_STOP = false;
-    private final Map<UUID, Location> cache = new HashMap<>();
-
-    /**
-     * Whether a glow check is currently being run.
-     */
-    private final AtomicBoolean executing = new AtomicBoolean();
+    private final Map<UUID, Location> cache = Collections.synchronizedMap(new HashMap<>());
 
     public AdvancedGlowVisibilityAddon() {
         new BukkitRunnable() {
@@ -63,13 +58,6 @@ public class AdvancedGlowVisibilityAddon {
                     EGlow.getInstance().setAdvancedGlowVisibility(null);
                     return;
                 }
-                if (executing.get()) {
-                    // This means either an exception was thrown, or the last executing is still running.
-                    // If it's still running, we don't have a way to stop it, so we'll let it finish to avoid any conflicts.
-                    // The odds of this actually happening are very low, as it would mean the calculation took more than half a second.
-                    return;
-                }
-                executing.set(true);
 
                 Collection<IEGlowPlayer> ePlayers = DataManager.getEGlowPlayers();
 
@@ -112,7 +100,6 @@ public class AdvancedGlowVisibilityAddon {
                         checkedPlayers.add(pair);
                     }
                 }
-                executing.set(false);
             }
         }.runTaskTimerAsynchronously(EGlow.getInstance(), 0, Math.max(EGlowMainConfig.MainConfig.ADVANCED_GLOW_VISIBILITY_DELAY.getInt(), 10));
     }
@@ -157,9 +144,7 @@ public class AdvancedGlowVisibilityAddon {
     }
 
     public void uncachePlayer(IEGlowPlayer ePlayer) {
-        synchronized (cache) {
-            cache.remove(ePlayer.getUUID());
-        }
+        cache.remove(ePlayer.getUUID());
     }
 
     public void shutdown() {


### PR DESCRIPTION
Previously, the visibility runnable would lock itself while running to ensure another run could not occur while the last was still going. The main downside to this was that it would stop working if an exception occurred anywhere inside.

The primary reason for this was to avoid the location cache being accessed and modified at the same time by two different threads.
This wasn't wholly prevented as when a player disconnects, it would synchronize on the map to remove them.

This fixes both of those problems by using a synchronized map. This special type of map wraps any other map, except all operations are synchronized on itself, fully preventing two threads from accessing it at the same time.

This is an acceptable solution here since the odds of two threads accessing it at the same time are extremely low, and the time it would have to wait for the previous operation to complete is very insignificant.