### PR TITLE
Properly shutdown advanced glow visibility

### DIFF
--- a/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
+++ b/src/main/java/me/MrGraycat/eGlow/Addon/Internal/AdvancedGlowVisibilityAddon.java
@@ -46,7 +46,7 @@ public class AdvancedGlowVisibilityAddon {
         ignoredBlocks.addAll(materials);
     }
 
-    private boolean FORCE_STOP = false;
+    private boolean shutdown = false;
     private final Map<UUID, Location> cache = new HashMap<>();
 
     /**
@@ -58,9 +58,8 @@ public class AdvancedGlowVisibilityAddon {
         new BukkitRunnable() {
             @Override
             public void run() {
-                if (getForceStop()) {
+                if (isShutdown()) {
                     cancel();
-                    EGlow.getInstance().setAdvancedGlowVisibility(null);
                     return;
                 }
                 if (executing.get()) {
@@ -162,20 +161,16 @@ public class AdvancedGlowVisibilityAddon {
         }
     }
 
-    public void shutdown() {
-        setForceStop();
-    }
-
     private int distance(Location start, Location end) {
         return (int) Math.floor(Math.sqrt(Math.pow((start.getX() - end.getX()), 2) + Math.pow((start.getY() - end.getY()), 2) + Math.pow((start.getZ() - end.getZ()), 2)));
     }
 
-    private void setForceStop() {
-        this.FORCE_STOP = true;
+    public void shutdown() {
+        this.shutdown = true;
     }
 
-    private boolean getForceStop() {
-        return this.FORCE_STOP;
+    private boolean isShutdown() {
+        return this.shutdown;
     }
 
     public static class Raytrace {

--- a/src/main/java/me/MrGraycat/eGlow/Command/SubCommands/Admin/ReloadCommand.java
+++ b/src/main/java/me/MrGraycat/eGlow/Command/SubCommands/Admin/ReloadCommand.java
@@ -91,14 +91,15 @@ public class ReloadCommand extends SubCommand {
 				}
 			}
 
-			if (MainConfig.ADVANCED_GLOW_VISIBILITY_ENABLE.getBoolean()) {
-				if (getInstance().getAdvancedGlowVisibility() == null)
-					getInstance().setAdvancedGlowVisibility(new AdvancedGlowVisibilityAddon());
-			} else {
-				if (getInstance().getAdvancedGlowVisibility() != null)
-					getInstance().setAdvancedGlowVisibility(null);
+			AdvancedGlowVisibilityAddon advGlowVis = getInstance().getAdvancedGlowVisibility();
+			if (advGlowVis != null) {
+				advGlowVis.shutdown();
 			}
-			
+			getInstance().setAdvancedGlowVisibility(MainConfig.ADVANCED_GLOW_VISIBILITY_ENABLE.getBoolean()
+					? new AdvancedGlowVisibilityAddon()
+					: null
+			);
+
 			try{
 			    String alias = MainConfig.COMMAND_ALIAS.getString();
 			    

--- a/src/main/java/me/MrGraycat/eGlow/EGlow.java
+++ b/src/main/java/me/MrGraycat/eGlow/EGlow.java
@@ -77,6 +77,9 @@ public class EGlow extends JavaPlugin {
 	
 	@Override
 	public void onDisable() {
+		if (getAdvancedGlowVisibility() != null) {
+			getAdvancedGlowVisibility().shutdown();
+		}
 		if (getLPAddon() != null) {
 			getLPAddon().unload();
 		}


### PR DESCRIPTION
This fixes the advanced glow visibility runnable not being properly shut down. This would lead to multiple instances of it running which could lead to weird behavior and an increased server load.

It will now be told to shut down when the plugin is disabled, and when the reload command is run.

It will also no longer set the EGlow instance of itself to null in the runnable because if it was shut down and a new one was created at the right time, during the next tick, the shutdown instance would clear the reference to the new one.