### PR TITLE
Fix NPE on disconnect when advanced glow vis is disabled

### DIFF
--- a/src/main/java/me/MrGraycat/eGlow/Event/EGlowEventListener.java
+++ b/src/main/java/me/MrGraycat/eGlow/Event/EGlowEventListener.java
@@ -202,7 +202,9 @@ public class EGlowEventListener implements Listener {
 			
 			PipelineInjector.uninject(eglowPlayer);
 			DataManager.removeEGlowPlayer(eglowPlayer.getPlayer());
-			EGlow.getInstance().getAdvancedGlowVisibility().uncachePlayer(eglowPlayer);
+			if (EGlow.getInstance().getAdvancedGlowVisibility() != null) {
+				EGlow.getInstance().getAdvancedGlowVisibility().uncachePlayer(eglowPlayer);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a harmless error on disconnect when advanced glow visibility is disabled as it was trying to uncache the player without the addon being enabled.