### PR TITLE
Fix Gradle version not being used in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: eGlow
 main: me.MrGraycat.eGlow.EGlow
-version: 3.1.9
+version: ${version}
 api-version: 1.13
 softdepend: [TAB,Citizens,PlaceholderAPI,Vault,iDisguise,LibsDisguises,ViaVersion,ProtocolSupport,LuckPerms]
 author: MrGraycat


### PR DESCRIPTION
Simple change to fix the Gradle version not being used in the plugin.yml.