### PR TITLE
Added Velocity Support

### DIFF
--- a/src/main/java/me/mrgraycat/eglow/addon/tab/TABAddon.java
+++ b/src/main/java/me/mrgraycat/eglow/addon/tab/TABAddon.java
@@ -40,7 +40,7 @@ public class TABAddon extends AbstractAddonBase {
 		if (tabPlugin == null) {
 			this.versionSupported = false;
 
-			if (DebugUtil.onBungee())
+			if (DebugUtil.onBungee() || DebugUtil.onVelocity())
 				getEGlowInstance().getServer().getPluginManager().registerEvents(new TABAddonEvents(), getEGlowInstance());
 			return;
 		}
@@ -171,7 +171,7 @@ public class TABAddon extends AbstractAddonBase {
 
 					if (tabAddon.isVersionSupported() && tabAddon.blockEGlowPackets()) {
 						tabAddon.updateTABPlayer(eGlowPlayer, eGlowPlayer.getActiveColor());
-					} else if (DebugUtil.onBungee()) {
+					} else if (DebugUtil.onBungee() || DebugUtil.onVelocity()) {
 						DataManager.TABProxyUpdateRequest(player, String.valueOf(eGlowPlayer.getActiveColor()));
 					}
 				} catch (ConcurrentModificationException ignored) {

--- a/src/main/java/me/mrgraycat/eglow/config/EGlowMainConfig.java
+++ b/src/main/java/me/mrgraycat/eglow/config/EGlowMainConfig.java
@@ -138,6 +138,7 @@ public class EGlowMainConfig {
 		SETTINGS_NOTIFICATIONS_INVISIBILITY("Settings.notifications.invisibility-change"),
 		SETTINGS_NOTIFICATIONS_TARGET_COMMAND("Settings.notifications.target-set-unset-command"),
 
+		ADVANCED_VELOCITY_MESSAGING("Advanced.use-velocity-plugin-messaging"),
 		ADVANCED_FORCE_DISABLE_PROXY_MESSAGING("Advanced.force-disable-proxy-messaging"),
 		ADVANCED_FORCE_DISABLE_TAB_INTEGRATION("Advanced.force-disable-tab-integration"),
 		ADVANCED_GLOW_VISIBILITY_ENABLE("Advanced.glow-visibility.enable"),

--- a/src/main/java/me/mrgraycat/eglow/util/DebugUtil.java
+++ b/src/main/java/me/mrgraycat/eglow/util/DebugUtil.java
@@ -10,6 +10,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
+import static me.mrgraycat.eglow.config.EGlowMainConfig.MainConfig.ADVANCED_VELOCITY_MESSAGING;
+
 public class DebugUtil {
 	private static final String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 	private static final int minorVersion = Integer.parseInt(version.split("_")[1]);
@@ -62,5 +64,9 @@ public class DebugUtil {
 
 	public static boolean onBungee() {
 		return !Bukkit.getServer().getOnlineMode() && NMSHook.isBungee();
+	}
+
+	public static boolean onVelocity(){
+		return ADVANCED_VELOCITY_MESSAGING.getBoolean();
 	}
 }

--- a/src/main/java/me/mrgraycat/eglow/util/packets/NMSHook.java
+++ b/src/main/java/me/mrgraycat/eglow/util/packets/NMSHook.java
@@ -31,6 +31,7 @@ public class NMSHook {
 	public static boolean isBungee() {
 		try {
 			return (Boolean) (nms.bungee.get(nms.SpigotConfig));
+
 		} catch (IllegalAccessException exception) {
 			ChatUtil.reportError(exception);
 			return false;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,6 +76,8 @@ Settings:
 #Advanced settings - Only edit these when you know what you're doing!
 #Disabling some of these settings may cause eGlow to not work properly
 Advanced:
+  #Use velocity plugin messaging if you are running EGlowTabProxy addon on Velocity
+  use-velocity-plugin-messaging: false
   #Disable the messaging between backend and proxy server (required for eGlow's proxy addon)
   force-disable-proxy-messaging: false
   #Disable the integration with TAB to have simple glow colors which gets controlled by the end of tagprefix in TAB


### PR DESCRIPTION
By adding a new parameter in the config, EGlow will now support Velocity plugin messaging while installing the Proxy Addon